### PR TITLE
Use absolute path to osx/ in DYLD_LIBRARY_PATH

### DIFF
--- a/precompiled/Kick
+++ b/precompiled/Kick
@@ -12,7 +12,7 @@ ARCH=`uname -m`
 # MonoKickstart picks the right libfolder, so just execute the right binary.
 if [ "$UNAME" == "Darwin" ]; then
 	# ... Except on OSX.
-	export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:./osx/
+	export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:"`pwd`"/osx/
 	./kick.bin.osx $@
 else
 	if [ "$ARCH" == "x86_64" ]; then


### PR DESCRIPTION
A game (or app, in my case) using MonoKickstart might change its working directory while running, making ./osx/ resolve to the wrong path.

I'm not entirely sure whether the syntax "`...`" is required (maybe `pwd` is enough? I don't do much bash) but it does work: I tried echo'ing $DYLD_LIBRARY_PATH, it looks right and my library loading issues are fixed.
