### PR TITLE
Add note about macOS notarization

### DIFF
--- a/README
+++ b/README
@@ -41,3 +41,10 @@ behavior by simply setting MONO_FORCE_COMPAT to a non-null value:
 https://github.com/openbsd/ports/commit/7670058636c4985f47fa8da6dceaa9e7fec4f933
 
 Thanks to the OpenBSD community for the fix!
+
+About macOS Notarization
+------------------------
+Starting with macOS Catalina, apps distributed outside the Mac App Store must be
+notarized to pass Gatekeeper checks. Follow this guide to notarize your app:
+
+https://gist.github.com/nickgravelyn/45a08b4a9500b93dd0ac11f984e6b9f7


### PR DESCRIPTION
For the sake of macOS developers who aren't totally comfortable telling their users to just disable Gatekeeper, it may be worth adding @nickgravelyn's [macOS notarization guide](https://gist.github.com/nickgravelyn/45a08b4a9500b93dd0ac11f984e6b9f7) to the README. (It was written for FNA games in particular, but there's nothing specific to FNA included in there.)

Thoughts? cc: @afrodynamics